### PR TITLE
fix: stabilize worktree management + add tests

### DIFF
--- a/src/commands/worktree.ts
+++ b/src/commands/worktree.ts
@@ -1,10 +1,10 @@
 import { loadConfig } from '../config.js';
 import { ConfigError, GithubError } from '../core/errors.js';
+import { createIssueSource } from '../core/issue-source.js';
 import { IssueStatus, setIssueStatus } from '../core/issue-status.js';
 import { logger } from '../core/logger.js';
 import { spawnLeadSession } from '../core/session-spawner.js';
 import { createWorktree, listWorktrees, removeWorktree } from '../core/worktree.js';
-import { getIssue } from '../github/issues.js';
 import { initVault } from '../obsidian/vault-init.js';
 
 function getArgValue(args: string[], flag: string): string | undefined {
@@ -71,10 +71,12 @@ export async function runWorktreeCreate(args: string[]): Promise<void> {
 
   const worktreePath = await createWorktree(config.targetRepo, branch, config.github.baseBranch);
 
+  const issueSource = createIssueSource(config);
+
   // Process issues sequentially in the same worktree
   for (const ref of issueRefs) {
     const issueNumber = parseIssueRef(ref);
-    const issue = await getIssue(config, issueNumber);
+    const issue = await issueSource.getIssue(issueNumber);
 
     logger.info(`[Issue #${issue.number}] ${issue.title}`);
     await setIssueStatus(config.github.repo, issue.number, IssueStatus.InProgress);
@@ -85,6 +87,15 @@ export async function runWorktreeCreate(args: string[]): Promise<void> {
       issueTitle: issue.title,
       issueBody: issue.body,
     });
+  }
+
+  if (config.worktree.autoClean) {
+    logger.info(`Auto-cleaning worktree at ${worktreePath}`);
+    try {
+      await removeWorktree(config.targetRepo, worktreePath);
+    } catch {
+      logger.warn(`Auto-clean failed for ${worktreePath} (may have uncommitted changes)`);
+    }
   }
 }
 

--- a/src/core/worktree.test.ts
+++ b/src/core/worktree.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+
+// Test the porcelain output parsing logic extracted for testability
+function parseWorktreeOutput(output: string): Array<{ path: string; branch: string; head: string }> {
+  const entries: Array<{ path: string; branch: string; head: string }> = [];
+  let current: { path?: string; branch?: string; head?: string } = {};
+
+  for (const line of output.split('\n')) {
+    if (line.startsWith('worktree ')) {
+      current.path = line.slice('worktree '.length);
+    } else if (line.startsWith('HEAD ')) {
+      current.head = line.slice('HEAD '.length);
+    } else if (line.startsWith('branch ')) {
+      current.branch = line.slice('branch refs/heads/'.length);
+    } else if (line === '') {
+      if (current.path && current.branch && current.head) {
+        entries.push(current as { path: string; branch: string; head: string });
+      }
+      current = {};
+    }
+  }
+
+  if (current.path && current.branch && current.head) {
+    entries.push(current as { path: string; branch: string; head: string });
+  }
+
+  return entries.slice(1); // skip main worktree
+}
+
+describe('worktree', () => {
+  describe('parseWorktreeOutput', () => {
+    it('should parse porcelain output correctly', () => {
+      const output = [
+        'worktree /repo',
+        'HEAD abc123',
+        'branch refs/heads/main',
+        '',
+        'worktree /repo/../worktree-feat/auth',
+        'HEAD def456',
+        'branch refs/heads/feat/auth',
+        '',
+        'worktree /repo/../worktree-fix/bug',
+        'HEAD ghi789',
+        'branch refs/heads/fix/bug',
+        '',
+      ].join('\n');
+
+      const result = parseWorktreeOutput(output);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].branch).toBe('feat/auth');
+      expect(result[1].branch).toBe('fix/bug');
+    });
+
+    it('should return empty for main-only worktree', () => {
+      const output = [
+        'worktree /repo',
+        'HEAD abc123',
+        'branch refs/heads/main',
+        '',
+      ].join('\n');
+
+      const result = parseWorktreeOutput(output);
+      expect(result).toHaveLength(0);
+    });
+
+    it('should handle missing fields gracefully', () => {
+      const output = [
+        'worktree /repo',
+        'HEAD abc123',
+        'branch refs/heads/main',
+        '',
+        'worktree /repo/../wt',
+        'HEAD def456',
+        '', // missing branch
+      ].join('\n');
+
+      const result = parseWorktreeOutput(output);
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/src/core/worktree.test.ts
+++ b/src/core/worktree.test.ts
@@ -1,31 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-// Test the porcelain output parsing logic extracted for testability
-function parseWorktreeOutput(output: string): Array<{ path: string; branch: string; head: string }> {
-  const entries: Array<{ path: string; branch: string; head: string }> = [];
-  let current: { path?: string; branch?: string; head?: string } = {};
-
-  for (const line of output.split('\n')) {
-    if (line.startsWith('worktree ')) {
-      current.path = line.slice('worktree '.length);
-    } else if (line.startsWith('HEAD ')) {
-      current.head = line.slice('HEAD '.length);
-    } else if (line.startsWith('branch ')) {
-      current.branch = line.slice('branch refs/heads/'.length);
-    } else if (line === '') {
-      if (current.path && current.branch && current.head) {
-        entries.push(current as { path: string; branch: string; head: string });
-      }
-      current = {};
-    }
-  }
-
-  if (current.path && current.branch && current.head) {
-    entries.push(current as { path: string; branch: string; head: string });
-  }
-
-  return entries.slice(1); // skip main worktree
-}
+import { parseWorktreeOutput } from './worktree.js';
 
 describe('worktree', () => {
   describe('parseWorktreeOutput', () => {
@@ -47,12 +22,13 @@ describe('worktree', () => {
 
       const result = parseWorktreeOutput(output);
 
-      expect(result).toHaveLength(2);
-      expect(result[0].branch).toBe('feat/auth');
-      expect(result[1].branch).toBe('fix/bug');
+      expect(result).toHaveLength(3);
+      expect(result[0].branch).toBe('main');
+      expect(result[1].branch).toBe('feat/auth');
+      expect(result[2].branch).toBe('fix/bug');
     });
 
-    it('should return empty for main-only worktree', () => {
+    it('should return single entry for main-only worktree', () => {
       const output = [
         'worktree /repo',
         'HEAD abc123',
@@ -61,7 +37,8 @@ describe('worktree', () => {
       ].join('\n');
 
       const result = parseWorktreeOutput(output);
-      expect(result).toHaveLength(0);
+      expect(result).toHaveLength(1);
+      expect(result[0].branch).toBe('main');
     });
 
     it('should handle missing fields gracefully', () => {
@@ -76,7 +53,7 @@ describe('worktree', () => {
       ].join('\n');
 
       const result = parseWorktreeOutput(output);
-      expect(result).toHaveLength(0);
+      expect(result).toHaveLength(1); // only the main entry
     });
   });
 });

--- a/src/core/worktree.ts
+++ b/src/core/worktree.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { access } from 'node:fs/promises';
 import { promisify } from 'node:util';
 import path from 'node:path';
 
@@ -14,8 +15,32 @@ export interface WorktreeInfo {
 }
 
 async function git(cwd: string, args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync('git', args, { cwd });
-  return stdout.trim();
+  try {
+    const { stdout } = await execFileAsync('git', args, { cwd });
+    return stdout.trim();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new ColonyError(`git ${args.join(' ')} failed: ${message}`, 'WORKTREE_ERROR');
+  }
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureBranchNotExists(targetRepo: string, branch: string): Promise<void> {
+  try {
+    await execFileAsync('git', ['rev-parse', '--verify', branch], { cwd: targetRepo });
+    throw new ColonyError(`Branch '${branch}' already exists`, 'WORKTREE_ERROR');
+  } catch (err) {
+    if (err instanceof ColonyError) throw err;
+    // Branch doesn't exist — good
+  }
 }
 
 export async function createWorktree(
@@ -25,6 +50,11 @@ export async function createWorktree(
 ): Promise<string> {
   const worktreePath = path.resolve(targetRepo, '..', `worktree-${branch}`);
 
+  if (await pathExists(worktreePath)) {
+    throw new ColonyError(`Worktree path already exists: ${worktreePath}`, 'WORKTREE_ERROR');
+  }
+
+  await ensureBranchNotExists(targetRepo, branch);
   await git(targetRepo, ['fetch', 'origin', baseBranch]);
   await git(targetRepo, ['worktree', 'add', '-b', branch, worktreePath, `origin/${baseBranch}`]);
 

--- a/src/core/worktree.ts
+++ b/src/core/worktree.ts
@@ -35,12 +35,12 @@ async function pathExists(p: string): Promise<boolean> {
 
 async function ensureBranchNotExists(targetRepo: string, branch: string): Promise<void> {
   try {
-    await execFileAsync('git', ['rev-parse', '--verify', branch], { cwd: targetRepo });
-    throw new ColonyError(`Branch '${branch}' already exists`, 'WORKTREE_ERROR');
-  } catch (err) {
-    if (err instanceof ColonyError) throw err;
-    // Branch doesn't exist — good
+    await git(targetRepo, ['rev-parse', '--verify', branch]);
+  } catch {
+    // git rev-parse failed → branch doesn't exist — this is the expected case
+    return;
   }
+  throw new ColonyError(`Branch '${branch}' already exists`, 'WORKTREE_ERROR');
 }
 
 export async function createWorktree(
@@ -62,8 +62,7 @@ export async function createWorktree(
   return worktreePath;
 }
 
-export async function listWorktrees(targetRepo: string): Promise<WorktreeInfo[]> {
-  const output = await git(targetRepo, ['worktree', 'list', '--porcelain']);
+export function parseWorktreeOutput(output: string): WorktreeInfo[] {
   const entries: WorktreeInfo[] = [];
   let current: Partial<WorktreeInfo> = {};
 
@@ -75,16 +74,23 @@ export async function listWorktrees(targetRepo: string): Promise<WorktreeInfo[]>
     } else if (line.startsWith('branch ')) {
       current.branch = line.slice('branch refs/heads/'.length);
     } else if (line === '') {
-      if (current.path && current.branch) {
+      if (current.path && current.branch && current.head) {
         entries.push(current as WorktreeInfo);
       }
       current = {};
     }
   }
 
-  if (current.path && current.branch) {
+  if (current.path && current.branch && current.head) {
     entries.push(current as WorktreeInfo);
   }
+
+  return entries;
+}
+
+export async function listWorktrees(targetRepo: string): Promise<WorktreeInfo[]> {
+  const output = await git(targetRepo, ['worktree', 'list', '--porcelain']);
+  const entries = parseWorktreeOutput(output);
 
   // Filter out main worktree (first entry is always the main one)
   return entries.slice(1);


### PR DESCRIPTION
## Summary
- Git command error handling with `ColonyError` (`WORKTREE_ERROR` code)
- Edge case guards: branch/path existence check before `createWorktree`
- Auto-clean: worktree removal after agent completes when `config.worktree.autoClean` is true
- Tests for porcelain output parsing (3 cases)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes (28 tests, 6 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)